### PR TITLE
Batch swap rebalancing. CORE-391

### DIFF
--- a/bloom-offchain-cardano/src/orders/limit.rs
+++ b/bloom-offchain-cardano/src/orders/limit.rs
@@ -7,7 +7,7 @@ use cml_crypto::{blake2b224, Ed25519KeyHash, RawBytesEncoding};
 use cml_multi_era::babbage::BabbageTransactionOutput;
 
 use bloom_offchain::execution_engine::liquidity_book::core::{Next, TerminalTake, Unit};
-use bloom_offchain::execution_engine::liquidity_book::fragment::{MarketTaker, TakerBehaviour};
+use bloom_offchain::execution_engine::liquidity_book::fragment::{MarketTaker, TakerBalance, TakerBehaviour};
 use bloom_offchain::execution_engine::liquidity_book::linear_output_relative;
 use bloom_offchain::execution_engine::liquidity_book::side::Side;
 use bloom_offchain::execution_engine::liquidity_book::time::TimeBounds;
@@ -114,6 +114,13 @@ impl Ord for LimitOrder {
         cmp_by_price
             .then(self.weight().cmp(&other.weight()))
             .then(self.stable_id().cmp(&other.stable_id()))
+    }
+}
+
+impl TakerBalance for LimitOrder {
+    fn balance(mut self, added_output: u64) -> Self {
+        self.output_amount += added_output;
+        self
     }
 }
 
@@ -402,15 +409,13 @@ pub struct LimitOrderBounds {
 
 #[cfg(test)]
 mod tests {
-    use cml_chain::address::{Address, EnterpriseAddress};
+    use cml_chain::address::Address;
     use cml_chain::assets::AssetBundle;
-    use cml_chain::certs::StakeCredential;
-    use cml_chain::genesis::network_info::NetworkInfo;
     use cml_chain::plutus::PlutusData;
     use cml_chain::transaction::DatumOption;
     use cml_chain::{PolicyId, Value};
     use cml_core::serialization::Deserialize;
-    use cml_crypto::{Bip32PrivateKey, Ed25519KeyHash, TransactionHash};
+    use cml_crypto::{Ed25519KeyHash, TransactionHash};
     use cml_multi_era::babbage::{BabbageFormatTxOut, BabbageTransactionOutput};
     use num_rational::Ratio;
     use type_equalities::IsEqual;

--- a/bloom-offchain-cardano/src/orders/mod.rs
+++ b/bloom-offchain-cardano/src/orders/mod.rs
@@ -6,7 +6,7 @@ use crate::orders::grid::GridOrder;
 use crate::orders::limit::{LimitOrder, LimitOrderBounds};
 use bloom_derivation::{MarketTaker, Stable, Tradable};
 use bloom_offchain::execution_engine::liquidity_book::core::{Next, TerminalTake, Unit};
-use bloom_offchain::execution_engine::liquidity_book::fragment::TakerBehaviour;
+use bloom_offchain::execution_engine::liquidity_book::fragment::{TakerBalance, TakerBehaviour};
 use bloom_offchain::execution_engine::liquidity_book::types::{InputAsset, OutputAsset};
 use spectrum_offchain::data::Has;
 use spectrum_offchain::ledger::TryFromLedger;
@@ -29,6 +29,15 @@ impl Display for AnyOrder {
         match self {
             AnyOrder::Limit(lo) => std::fmt::Display::fmt(&lo, f),
             AnyOrder::Grid(go) => std::fmt::Display::fmt(&go, f),
+        }
+    }
+}
+
+impl TakerBalance for AnyOrder {
+    fn balance(self, added_output: u64) -> Self {
+        match self {
+            AnyOrder::Limit(o) => AnyOrder::Limit(o.balance(added_output)),
+            AnyOrder::Grid(o) => AnyOrder::Grid(o.balance(added_output)),
         }
     }
 }

--- a/bloom-offchain/src/execution_engine/liquidity_book/core.rs
+++ b/bloom-offchain/src/execution_engine/liquidity_book/core.rs
@@ -14,15 +14,17 @@ use algebra_core::semigroup::Semigroup;
 use spectrum_offchain::data::Stable;
 
 use crate::execution_engine::bundled::Bundled;
-use crate::execution_engine::liquidity_book::fragment::{MarketTaker, TakerBehaviour};
-use crate::execution_engine::liquidity_book::market_maker::{AbsoluteReserves, MarketMaker};
+use crate::execution_engine::liquidity_book::fragment::{MarketTaker, TakerBalance, TakerBehaviour};
+use crate::execution_engine::liquidity_book::market_maker::{
+    AbsoluteReserves, Excess, MakerBalance, MarketMaker,
+};
 use crate::execution_engine::liquidity_book::side::{OnSide, Side};
 use crate::execution_engine::liquidity_book::types::{FeeAsset, InputAsset, OutputAsset};
 
 /// Terminal state of a take that was fulfilled.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct TerminalTake {
-    /// Input asset removed as a result of this transaction.
+    /// Remainder of input asset.
     pub remaining_input: InputAsset<u64>,
     /// Output asset added as a result of this transaction.
     pub accumulated_output: OutputAsset<u64>,
@@ -40,6 +42,12 @@ impl TerminalTake {
         let real_delta = updated_budget_remainder - budget_remainder;
         self.remaining_budget = updated_budget_remainder as u64;
         (real_delta, self)
+    }
+}
+
+impl TakerBalance for TerminalTake {
+    fn balance(self, added_output: u64) -> Self {
+        todo!()
     }
 }
 
@@ -551,6 +559,59 @@ impl<Taker: Stable, Maker: Stable, U> MatchmakingAttempt<Taker, Maker, U> {
         self.makes.insert(sid, maker_combined);
         Ok(())
     }
+
+    pub fn try_balance(self) -> Option<Self>
+    where
+        Maker: MakerBalance,
+        Taker: MarketTaker + TakerBalance,
+    {
+        let (mut excess_base, mut excess_quote) = (0u64, 0u64);
+        let Self {
+            takes,
+            makes,
+            execution_units_consumed,
+        } = self;
+        let mut balanced_makes = vec![];
+        for (id, make) in makes {
+            let target = make.target;
+            match make.result {
+                Next::Succ(next) => {
+                    let (balanced_next, Excess { base, quote }) = target.balance(next)?;
+                    balanced_makes.push((id, MakeInProgress::new(target, Next::Succ(balanced_next))));
+                    excess_base += base;
+                    excess_quote += quote;
+                }
+                Next::Term(next) => {
+                    balanced_makes.push((id, MakeInProgress::new(target, Next::Term(next))));
+                }
+            }
+        }
+        let mut balanced_takes = vec![];
+        for (id, take) in takes {
+            let excess = match take.target.side() {
+                Side::Bid => &mut excess_base,
+                Side::Ask => &mut excess_quote,
+            };
+            if *excess > 0 {
+                let result = match take.result {
+                    Next::Succ(take) => Next::Succ(take.balance(*excess)),
+                    Next::Term(take) => Next::Term(take.balance(*excess)),
+                };
+                *excess = 0;
+                balanced_takes.push((id, TakeInProgress::new(take.target, result)));
+            } else {
+                balanced_takes.push((id, take));
+            }
+        }
+        if excess_base == 0 && excess_quote == 0 {
+            return Some(Self {
+                takes: HashMap::from_iter(balanced_takes),
+                makes: HashMap::from_iter(balanced_makes),
+                execution_units_consumed,
+            });
+        }
+        None
+    }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -585,26 +646,28 @@ where
 {
     pub fn try_from<U>(attempt: MatchmakingAttempt<Taker, Maker, U>) -> Result<Self, Option<Vec<Taker>>>
     where
-        Taker: MarketTaker + Copy,
+        Maker: MakerBalance,
+        Taker: MarketTaker + TakerBalance + Copy,
     {
         if attempt.is_complete() {
-            let unsatisfied_fragments = attempt.unsatisfied_fragments();
-            if unsatisfied_fragments.is_empty() {
-                let MatchmakingAttempt { takes, makes, .. } = attempt;
-                let mut instructions = vec![];
-                for take in takes.into_values() {
-                    instructions.push(Either::Left(take));
-                }
-                for make in makes.into_values() {
-                    instructions.push(Either::Right(make));
-                }
-                Ok(Self { instructions })
-            } else {
-                Err(Some(unsatisfied_fragments))
+            if let Some(balanced_attempt) = attempt.try_balance() {
+                let unsatisfied_fragments = balanced_attempt.unsatisfied_fragments();
+                return if unsatisfied_fragments.is_empty() {
+                    let MatchmakingAttempt { takes, makes, .. } = balanced_attempt;
+                    let mut instructions = vec![];
+                    for take in takes.into_values() {
+                        instructions.push(Either::Left(take));
+                    }
+                    for make in makes.into_values() {
+                        instructions.push(Either::Right(make));
+                    }
+                    Ok(Self { instructions })
+                } else {
+                    Err(Some(unsatisfied_fragments))
+                };
             }
-        } else {
-            Err(None)
         }
+        Err(None)
     }
 }
 

--- a/bloom-offchain/src/execution_engine/liquidity_book/core.rs
+++ b/bloom-offchain/src/execution_engine/liquidity_book/core.rs
@@ -46,8 +46,9 @@ impl TerminalTake {
 }
 
 impl TakerBalance for TerminalTake {
-    fn balance(self, added_output: u64) -> Self {
-        todo!()
+    fn balance(mut self, added_output: u64) -> Self {
+        self.accumulated_output += added_output;
+        self
     }
 }
 

--- a/bloom-offchain/src/execution_engine/liquidity_book/fragment.rs
+++ b/bloom-offchain/src/execution_engine/liquidity_book/fragment.rs
@@ -14,6 +14,10 @@ pub trait TakerBehaviour: Sized {
     fn with_budget_corrected(self, delta: i64) -> (i64, Self);
 }
 
+pub trait TakerBalance: Sized {
+    fn balance(self, added_output: u64) -> Self;
+}
+
 /// Immutable discrete fragment of liquidity available at a specified timeframe at a specified price.
 /// MarketTaker is a projection of an order [TakerBehaviour] at a specific point on time axis.
 pub trait MarketTaker {

--- a/bloom-offchain/src/execution_engine/liquidity_book/market_maker.rs
+++ b/bloom-offchain/src/execution_engine/liquidity_book/market_maker.rs
@@ -45,6 +45,15 @@ pub trait MakerBehavior: Sized {
     fn swap(self, input: OnSide<u64>) -> Next<Self, Unit>;
 }
 
+pub struct Excess {
+    pub base: u64,
+    pub quote: u64,
+}
+
+pub trait MakerBalance: Sized {
+    fn balance(&self, that: Self) -> Option<(Self, Excess)>;
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Into, From, Display)]
 pub struct PoolQuality(u128);
 

--- a/bloom-offchain/src/execution_engine/liquidity_book/market_maker.rs
+++ b/bloom-offchain/src/execution_engine/liquidity_book/market_maker.rs
@@ -45,6 +45,7 @@ pub trait MakerBehavior: Sized {
     fn swap(self, input: OnSide<u64>) -> Next<Self, Unit>;
 }
 
+#[derive(Debug, Eq, PartialEq)]
 pub struct Excess {
     pub base: u64,
     pub quote: u64,

--- a/bloom-offchain/src/execution_engine/liquidity_book/mod.rs
+++ b/bloom-offchain/src/execution_engine/liquidity_book/mod.rs
@@ -10,8 +10,8 @@ use crate::display::{display_option, display_tuple};
 use crate::execution_engine::liquidity_book::core::{
     MakeInProgress, MatchmakingAttempt, MatchmakingRecipe, Next, TakeInProgress, Trans,
 };
-use crate::execution_engine::liquidity_book::fragment::{MarketTaker, TakerBehaviour};
-use crate::execution_engine::liquidity_book::market_maker::{MakerBehavior, MarketMaker, SpotPrice};
+use crate::execution_engine::liquidity_book::fragment::{MarketTaker, TakerBalance, TakerBehaviour};
+use crate::execution_engine::liquidity_book::market_maker::{MakerBalance, MakerBehavior, MarketMaker, SpotPrice};
 use spectrum_offchain::data::{Has, Stable};
 use spectrum_offchain::maker::Maker;
 
@@ -126,8 +126,8 @@ where
 
 impl<Taker, Maker, U> TemporalLiquidityBook<Taker, Maker> for TLB<Taker, Maker, U>
 where
-    Taker: Stable + MarketTaker<U = U> + TakerBehaviour + Ord + Copy + Display,
-    Maker: Stable + MarketMaker<U = U> + MakerBehavior + Copy + Display,
+    Taker: Stable + MarketTaker<U = U> + TakerBehaviour + TakerBalance + Ord + Copy + Display,
+    Maker: Stable + MarketMaker<U = U> + MakerBehavior + MakerBalance + Copy + Display,
     U: Monoid + AddAssign + PartialOrd + Copy,
 {
     fn attempt(&mut self) -> Option<MatchmakingRecipe<Taker, Maker>> {

--- a/bloom-offchain/src/execution_engine/liquidity_book/state/mod.rs
+++ b/bloom-offchain/src/execution_engine/liquidity_book/state/mod.rs
@@ -1471,7 +1471,7 @@ pub mod tests {
                     Next::Succ(pool) => Some(pool),
                     Next::Term(_) => None,
                 }?;
-                let excess_quote = rebalanced.reserves_quote.checked_sub(that.reserves_quote)?;
+                let excess_quote = that.reserves_quote.checked_sub(rebalanced.reserves_quote)?;
                 let delta = Excess {
                     base: 0,
                     quote: excess_quote,
@@ -1485,7 +1485,7 @@ pub mod tests {
                     Next::Succ(pool) => Some(pool),
                     Next::Term(_) => None,
                 }?;
-                let excess_base = rebalanced.reserves_base.checked_sub(that.reserves_base)?;
+                let excess_base = that.reserves_base.checked_sub(rebalanced.reserves_base)?;
                 let delta = Excess {
                     base: excess_base,
                     quote: 0,

--- a/bloom-offchain/src/execution_engine/liquidity_book/state/mod.rs
+++ b/bloom-offchain/src/execution_engine/liquidity_book/state/mod.rs
@@ -938,7 +938,9 @@ pub mod tests {
 
     use crate::execution_engine::liquidity_book::core::{Next, TerminalTake, Trans, Unit};
     use crate::execution_engine::liquidity_book::fragment::{MarketTaker, TakerBalance, TakerBehaviour};
-    use crate::execution_engine::liquidity_book::market_maker::{AbsoluteReserves, Excess, MakerBalance, MakerBehavior, MarketMaker, SpotPrice};
+    use crate::execution_engine::liquidity_book::market_maker::{
+        AbsoluteReserves, Excess, MakerBalance, MakerBehavior, MarketMaker, SpotPrice,
+    };
     use crate::execution_engine::liquidity_book::side::{OnSide, Side};
     use crate::execution_engine::liquidity_book::state::{
         AllowedPriceRange, Chronology, IdleState, MarketMakers, PartialPreviewState, PoolQuality,
@@ -1457,7 +1459,7 @@ pub mod tests {
             true
         }
     }
-    
+
     impl MakerBalance for SimpleCFMMPool {
         fn balance(&self, that: Self) -> Option<(Self, Excess)> {
             let drx = that.reserves_base.checked_sub(self.reserves_quote);
@@ -1478,7 +1480,7 @@ pub mod tests {
             } else {
                 // input is quote
                 let trade_input = that.reserves_quote.checked_sub(self.reserves_quote)?;
-                let side = Side::Bid ;
+                let side = Side::Bid;
                 let rebalanced = match self.swap(side.wrap(trade_input)) {
                     Next::Succ(pool) => Some(pool),
                     Next::Term(_) => None,

--- a/spectrum-cardano-lib/src/protocol_params.rs
+++ b/spectrum-cardano-lib/src/protocol_params.rs
@@ -9,7 +9,6 @@ const MAX_VALUE_SIZE: u32 = 5000;
 
 const COINS_PER_UTXO_BYTE: u64 = 4310;
 
-//todo: check correctness
 pub fn constant_tx_builder() -> TransactionBuilder {
     create_tx_builder_full(
         LinearFee::new(44, 155381),

--- a/spectrum-offchain-cardano/src/data/balance_pool.rs
+++ b/spectrum-offchain-cardano/src/data/balance_pool.rs
@@ -423,7 +423,7 @@ impl MakerBalance for BalancePool {
                 Next::Succ(pool) => Some(pool),
                 Next::Term(_) => None,
             }?;
-            let excess_y = rebalanced.reserves_y.checked_sub(&that.reserves_y)?.untag();
+            let excess_y = that.reserves_y.checked_sub(&rebalanced.reserves_y)?.untag();
             let delta = if x == base {
                 Excess {
                     base: 0,
@@ -444,7 +444,7 @@ impl MakerBalance for BalancePool {
                 Next::Succ(pool) => Some(pool),
                 Next::Term(_) => None,
             }?;
-            let excess_x = rebalanced.reserves_x.checked_sub(&that.reserves_x)?.untag();
+            let excess_x = that.reserves_x.checked_sub(&rebalanced.reserves_x)?.untag();
             let delta = if x == base {
                 Excess {
                     base: excess_x,

--- a/spectrum-offchain-cardano/src/data/balance_pool.rs
+++ b/spectrum-offchain-cardano/src/data/balance_pool.rs
@@ -19,7 +19,7 @@ use primitive_types::U512;
 
 use bloom_offchain::execution_engine::liquidity_book::core::{MakeInProgress, Next, Trans, Unit};
 use bloom_offchain::execution_engine::liquidity_book::market_maker::{
-    AbsoluteReserves, MakerBehavior, MarketMaker, PoolQuality, SpotPrice,
+    AbsoluteReserves, Excess, MakerBalance, MakerBehavior, MarketMaker, PoolQuality, SpotPrice,
 };
 use bloom_offchain::execution_engine::liquidity_book::side::{OnSide, Side};
 use bloom_offchain::execution_engine::liquidity_book::types::AbsolutePrice;
@@ -406,6 +406,58 @@ impl AMMOps for BalancePool {
             self.liquidity,
             burned_lq,
         )
+    }
+}
+
+impl MakerBalance for BalancePool {
+    fn balance(&self, that: Self) -> Option<(Self, Excess)> {
+        let x = self.asset_x.untag();
+        let y = self.asset_y.untag();
+        let [base, _] = order_canonical(x, y);
+        let drx = that.reserves_x.checked_sub(&self.reserves_x).map(|x| x.untag());
+        if let Some(drx) = drx {
+            // input is X
+            let trade_input = drx;
+            let side = if x == base { Side::Ask } else { Side::Bid };
+            let rebalanced = match self.swap(side.wrap(trade_input)) {
+                Next::Succ(pool) => Some(pool),
+                Next::Term(_) => None,
+            }?;
+            let excess_y = rebalanced.reserves_y.checked_sub(&that.reserves_y)?.untag();
+            let delta = if x == base {
+                Excess {
+                    base: 0,
+                    quote: excess_y,
+                }
+            } else {
+                Excess {
+                    base: excess_y,
+                    quote: 0,
+                }
+            };
+            Some((rebalanced, delta))
+        } else {
+            // input is Y
+            let trade_input = that.reserves_y.untag().checked_sub(self.reserves_y.untag())?;
+            let side = if y == base { Side::Ask } else { Side::Bid };
+            let rebalanced = match self.swap(side.wrap(trade_input)) {
+                Next::Succ(pool) => Some(pool),
+                Next::Term(_) => None,
+            }?;
+            let excess_x = rebalanced.reserves_x.checked_sub(&that.reserves_x)?.untag();
+            let delta = if x == base {
+                Excess {
+                    base: excess_x,
+                    quote: 0,
+                }
+            } else {
+                Excess {
+                    base: 0,
+                    quote: excess_x,
+                }
+            };
+            Some((rebalanced, delta))
+        }
     }
 }
 

--- a/spectrum-offchain-cardano/src/data/pool.rs
+++ b/spectrum-offchain-cardano/src/data/pool.rs
@@ -20,7 +20,7 @@ use log::info;
 use bloom_offchain::execution_engine::bundled::Bundled;
 use bloom_offchain::execution_engine::liquidity_book::core::{MakeInProgress, Next, Unit};
 use bloom_offchain::execution_engine::liquidity_book::market_maker::{
-    AbsoluteReserves, MakerBehavior, MarketMaker, PoolQuality, SpotPrice,
+    AbsoluteReserves, Excess, MakerBalance, MakerBehavior, MarketMaker, PoolQuality, SpotPrice,
 };
 use bloom_offchain::execution_engine::liquidity_book::side::OnSide;
 use bloom_offchain::execution_engine::liquidity_book::types::AbsolutePrice;
@@ -260,6 +260,21 @@ impl Display for AnyPool {
 pub struct PoolAssetMapping {
     pub asset_to_deduct_from: AssetClass,
     pub asset_to_add_to: AssetClass,
+}
+
+impl MakerBalance for AnyPool {
+    fn balance(&self, that: Self) -> Option<(Self, Excess)> {
+        match (self, that) {
+            (PureCFMM(p), PureCFMM(that)) => p.balance(that).map(|(that, excess)| (PureCFMM(that), excess)),
+            (BalancedCFMM(p), BalancedCFMM(that)) => {
+                p.balance(that).map(|(that, excess)| (BalancedCFMM(that), excess))
+            }
+            (StableCFMM(p), StableCFMM(that)) => {
+                p.balance(that).map(|(that, excess)| (StableCFMM(that), excess))
+            }
+            _ => None,
+        }
+    }
 }
 
 impl MakerBehavior for AnyPool {

--- a/spectrum-offchain-cardano/src/data/stable_pool_t2t.rs
+++ b/spectrum-offchain-cardano/src/data/stable_pool_t2t.rs
@@ -3,7 +3,7 @@ use std::ops::Mul;
 
 use bloom_offchain::execution_engine::liquidity_book::core::{Next, Unit};
 use bloom_offchain::execution_engine::liquidity_book::market_maker::{
-    AbsoluteReserves, MakerBehavior, MarketMaker, PoolQuality, SpotPrice,
+    AbsoluteReserves, Excess, MakerBalance, MakerBehavior, MarketMaker, PoolQuality, SpotPrice,
 };
 use cml_chain::address::Address;
 use cml_chain::assets::MultiAsset;
@@ -395,6 +395,58 @@ impl AMMOps for StablePoolT2T {
             self.liquidity,
             burned_lq,
         )
+    }
+}
+
+impl MakerBalance for StablePoolT2T {
+    fn balance(&self, that: Self) -> Option<(Self, Excess)> {
+        let x = self.asset_x.untag();
+        let y = self.asset_y.untag();
+        let [base, _] = order_canonical(x, y);
+        let drx = that.reserves_x.checked_sub(&self.reserves_x).map(|x| x.untag());
+        if let Some(drx) = drx {
+            // input is X
+            let trade_input = drx;
+            let side = if x == base { Side::Ask } else { Side::Bid };
+            let rebalanced = match self.swap(side.wrap(trade_input)) {
+                Next::Succ(pool) => Some(pool),
+                Next::Term(_) => None,
+            }?;
+            let excess_y = rebalanced.reserves_y.checked_sub(&that.reserves_y)?.untag();
+            let delta = if x == base {
+                Excess {
+                    base: 0,
+                    quote: excess_y,
+                }
+            } else {
+                Excess {
+                    base: excess_y,
+                    quote: 0,
+                }
+            };
+            Some((rebalanced, delta))
+        } else {
+            // input is Y
+            let trade_input = that.reserves_y.untag().checked_sub(self.reserves_y.untag())?;
+            let side = if y == base { Side::Ask } else { Side::Bid };
+            let rebalanced = match self.swap(side.wrap(trade_input)) {
+                Next::Succ(pool) => Some(pool),
+                Next::Term(_) => None,
+            }?;
+            let excess_x = rebalanced.reserves_x.checked_sub(&that.reserves_x)?.untag();
+            let delta = if x == base {
+                Excess {
+                    base: excess_x,
+                    quote: 0,
+                }
+            } else {
+                Excess {
+                    base: 0,
+                    quote: excess_x,
+                }
+            };
+            Some((rebalanced, delta))
+        }
     }
 }
 

--- a/spectrum-offchain-cardano/src/data/stable_pool_t2t.rs
+++ b/spectrum-offchain-cardano/src/data/stable_pool_t2t.rs
@@ -412,7 +412,7 @@ impl MakerBalance for StablePoolT2T {
                 Next::Succ(pool) => Some(pool),
                 Next::Term(_) => None,
             }?;
-            let excess_y = rebalanced.reserves_y.checked_sub(&that.reserves_y)?.untag();
+            let excess_y = that.reserves_y.checked_sub(&rebalanced.reserves_y)?.untag();
             let delta = if x == base {
                 Excess {
                     base: 0,
@@ -433,7 +433,7 @@ impl MakerBalance for StablePoolT2T {
                 Next::Succ(pool) => Some(pool),
                 Next::Term(_) => None,
             }?;
-            let excess_x = rebalanced.reserves_x.checked_sub(&that.reserves_x)?.untag();
+            let excess_x = that.reserves_x.checked_sub(&rebalanced.reserves_x)?.untag();
             let delta = if x == base {
                 Excess {
                     base: excess_x,


### PR DESCRIPTION
Once MatchmakingAttempt is formed we recalculate swaps in each AMM, the excess (if any) is always on the output side, so we can safely spread it across takers (we only add output to them, so we don't have to care about price conditions checks or state transitions caused by this action). 