### PR TITLE
Fill in gaps to address some stressors in `splash-sys` (DEX-966)

### DIFF
--- a/spectrum-cardano-lib/src/time.rs
+++ b/spectrum-cardano-lib/src/time.rs
@@ -13,3 +13,11 @@ pub fn slot_to_posix(slot: u64, network_id: NetworkId) -> u64 {
         1591566291 + slot
     }
 }
+
+pub fn posix_to_slot(posix: u64, network_id: NetworkId) -> u64 {
+    if network_id == NetworkId::PREPROD {
+        posix - 1655683200
+    } else {
+        posix - 1591566291
+    }
+}

--- a/splash-dao-administration/src/main.rs
+++ b/splash-dao-administration/src/main.rs
@@ -398,15 +398,7 @@ async fn deploy<'a>(
             }
         };
 
-        // Buffer wallet validator is a 2-of-n multisig native script
-        let authorised_pubkeys = dao_parameters
-            .dao_authorized_executors
-            .iter()
-            .map(|key_hash| NativeScript::new_script_pubkey(*key_hash))
-            .collect();
-        let buffer_wallet = NativeScript::new_script_n_of_k(2, authorised_pubkeys);
-
-        // --------
+        // -----------------------------------------------------------------------------------------
         let dsd = DaoScriptData::global();
         let d = DeployedValidators {
             inflation: DeployedValidatorRef {

--- a/splash-dao-offchain/src/routines/mod.rs
+++ b/splash-dao-offchain/src/routines/mod.rs
@@ -71,7 +71,7 @@ use pallas_network::miniprotocols::localtxsubmission::cardano_node_errors::{
     ApplyTxError, ConwayLedgerPredFailure, ConwayUtxoPredFailure, ConwayUtxowPredFailure,
 };
 use spectrum_cardano_lib::output::FinalizedTxOut;
-use spectrum_cardano_lib::time::slot_to_time_millis;
+use spectrum_cardano_lib::time::{posix_to_slot, slot_to_time_millis};
 use spectrum_cardano_lib::{AssetName, NetworkId, OutputRef};
 use spectrum_offchain::backlog::data::{OrderWeight, Weighted};
 use spectrum_offchain::backlog::ResilientBacklog;
@@ -2496,6 +2496,17 @@ pub fn time_millis_to_epoch(time_millis: u64, genesis_time: GenesisEpochStartTim
 pub fn slot_to_epoch(slot: u64, genesis_time: GenesisEpochStartTime, network_id: NetworkId) -> CurrentEpoch {
     let time_millis = slot_to_time_millis(slot, network_id);
     time_millis_to_epoch(time_millis, genesis_time)
+}
+
+pub fn last_slot_of_epoch(
+    epoch: CurrentEpoch,
+    genesis_time: GenesisEpochStartTime,
+    network_id: NetworkId,
+) -> u64 {
+    let start_time = u64::from(genesis_time);
+    let next_epoch = (epoch.0 + 1) as u64;
+    let end_time_posix = (start_time + next_epoch * EPOCH_LEN - 1) / 1000;
+    posix_to_slot(end_time_posix, network_id)
 }
 
 pub enum EpochRoutineState<Out> {

--- a/splash-lp-indexer/src/position_db/mature_events.rs
+++ b/splash-lp-indexer/src/position_db/mature_events.rs
@@ -160,7 +160,7 @@ fn prepare_positions_for_update(
                     .iter()
                     .map(|e| {
                         (
-                            e.fist_slot(slots_in_epoch, epoch_start),
+                            e.first_slot(slots_in_epoch, epoch_start),
                             e.last_slot(slots_in_epoch, epoch_start),
                         )
                     })

--- a/splash-reward-distributor/src/config.rs
+++ b/splash-reward-distributor/src/config.rs
@@ -34,6 +34,7 @@ pub struct AppConfig {
     pub ve_config: VeConfig,
     pub authorized_executors: Vec<PublicKey>,
     pub operator_sk: String,
+    pub reward_tx_ttl_in_slots: u64,
 }
 
 #[derive(serde::Deserialize)]

--- a/splash-reward-distributor/src/context.rs
+++ b/splash-reward-distributor/src/context.rs
@@ -27,6 +27,7 @@ pub struct VerifierRuntimeContext {
     pub network_id: NetworkId,
     pub genesis_epoch_start_time: GenesisEpochStartTime,
     pub authorized_executors: AuthorizedExecutors,
+    pub reward_tx_ttl: RewardTxTtl,
 }
 
 has_deployed_validator!(
@@ -122,6 +123,16 @@ impl Has<OperatorCreds> for VerifierRuntimeContext {
             Credential::new_pub_key(dummy_key_hash),
         ));
         OperatorCreds(dummy_key_hash, dummy_address)
+    }
+}
+
+/// TX TTL for both harvest and gauge buffering TXs (specified in # slots).
+#[derive(Clone, Copy)]
+pub struct RewardTxTtl(pub u64);
+
+impl Has<RewardTxTtl> for VerifierRuntimeContext {
+    fn select<U: IsEqual<RewardTxTtl>>(&self) -> RewardTxTtl {
+        self.reward_tx_ttl
     }
 }
 
@@ -226,5 +237,11 @@ impl Has<GenesisEpochStartTime> for RewardBotRuntimeContext {
 impl Has<AuthorizedExecutors> for RewardBotRuntimeContext {
     fn select<U: IsEqual<AuthorizedExecutors>>(&self) -> AuthorizedExecutors {
         self.verifier_runtime_context.authorized_executors.clone()
+    }
+}
+
+impl Has<RewardTxTtl> for RewardBotRuntimeContext {
+    fn select<U: IsEqual<RewardTxTtl>>(&self) -> RewardTxTtl {
+        self.verifier_runtime_context.reward_tx_ttl
     }
 }

--- a/splash-reward-distributor/src/engine/executor.rs
+++ b/splash-reward-distributor/src/engine/executor.rs
@@ -27,10 +27,10 @@ use log::{error, warn};
 use pallas_network::miniprotocols::localtxsubmission::cardano_node_errors::{
     ApplyTxError, ConwayLedgerPredFailure, ConwayUtxoPredFailure, ConwayUtxowPredFailure, TxInput,
 };
-use rs_merkle::algorithms::Keccak256;
 use rs_merkle::MerkleTree;
-use serde::de::DeserializeOwned;
+use rs_merkle::algorithms::Keccak256;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use spectrum_cardano_lib::collateral::Collateral;
 use spectrum_cardano_lib::hash::hash_transaction_canonical;
 use spectrum_cardano_lib::output::FinalizedTxOut;
@@ -39,12 +39,13 @@ use spectrum_cardano_lib::transaction::TransactionOutputExtension;
 use spectrum_cardano_lib::types::TryFromPData;
 use spectrum_cardano_lib::value::ValueExtension;
 use spectrum_cardano_lib::{AssetClass, AssetName, NetworkId, OutputRef, Token};
-use spectrum_offchain::domain::event::Predicted;
 use spectrum_offchain::domain::Has;
+use spectrum_offchain::domain::event::Predicted;
 use spectrum_offchain::network::Network;
 use spectrum_offchain::tx_hash::CanonicalHash;
 use spectrum_offchain_cardano::deployment::DeployedValidator;
 use spectrum_offchain_cardano::tx_submission::RejectReasons;
+use splash_dao_offchain::GenesisEpochStartTime;
 use splash_dao_offchain::constants::SPLASH_NAME;
 use splash_dao_offchain::deployment::{DaoScriptData, ProtocolValidator};
 use splash_dao_offchain::entities::onchain::funding_box::{FundingBox, FundingBoxId};
@@ -52,15 +53,14 @@ use splash_dao_offchain::entities::onchain::smart_farm::{self, FarmId};
 use splash_dao_offchain::funding::{AvailableFundingBoxes, FundingRepo};
 use splash_dao_offchain::protocol_config::{OperatorCreds, SplashPolicy};
 use splash_dao_offchain::routines::actions::{BlueprintEstimates, DaoTxBlueprint};
-use splash_dao_offchain::routines::{slot_to_epoch, time_millis_to_epoch, FundingBoxChanges, Slot};
-use splash_dao_offchain::GenesisEpochStartTime;
+use splash_dao_offchain::routines::{FundingBoxChanges, Slot, slot_to_epoch, time_millis_to_epoch};
+use splash_yf_offchain::Epoch;
 use splash_yf_offchain::entities::buffer_wallet::{
     BufferWallet, BufferWalletAction, BufferWalletConfig, BufferWalletWrap,
 };
 use splash_yf_offchain::entities::gauge::Gauge;
 use splash_yf_offchain::entities::harvest_order::{HarvestOrder, HarvestOrderAction};
 use splash_yf_offchain::events::EntityUpdated;
-use splash_yf_offchain::Epoch;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -364,10 +364,12 @@ where
             let splash_policy = self.ctx.select::<SplashPolicy>().0;
             let splash_asset_class = AssetClass::Token(Token(splash_policy, splash_asset_name));
 
-            assert!(bw_out
-                .value_mut()
-                .checked_sub(&make_splash_value(splash_asset_class, batch.total_payout))
-                .is_ok());
+            assert!(
+                bw_out
+                    .value_mut()
+                    .checked_sub(&make_splash_value(splash_asset_class, batch.total_payout))
+                    .is_ok()
+            );
 
             let buffer_wallet_output = TransactionOutputBuilder::new()
                 .with_address(bw_out.address().clone())
@@ -892,19 +894,19 @@ pub struct Executor<
 }
 
 impl<
-        GaugeId,
-        StateId,
-        Bearer,
-        Tx,
-        TxInputs,
-        Ctx,
-        TxErr,
-        PositionIndex,
-        OnChainIndex,
-        FundingIndex,
-        TxSubmit,
-        Verifier,
-    >
+    GaugeId,
+    StateId,
+    Bearer,
+    Tx,
+    TxInputs,
+    Ctx,
+    TxErr,
+    PositionIndex,
+    OnChainIndex,
+    FundingIndex,
+    TxSubmit,
+    Verifier,
+>
     Executor<
         GaugeId,
         StateId,
@@ -943,18 +945,18 @@ impl<
 
 #[async_trait]
 impl<
-        GaugeId,
-        StateId,
-        Bearer,
-        Tx,
-        TxInputs,
-        Ctx,
-        PositionIndex,
-        OnChainIndex,
-        FundingIndex,
-        TxSubmit,
-        Verifier,
-    > BatchExecutor<TaskId, Task<GaugeId, StateId>, TransactionHash, Error>
+    GaugeId,
+    StateId,
+    Bearer,
+    Tx,
+    TxInputs,
+    Ctx,
+    PositionIndex,
+    OnChainIndex,
+    FundingIndex,
+    TxSubmit,
+    Verifier,
+> BatchExecutor<TaskId, Task<GaugeId, StateId>, TransactionHash, Error>
     for Executor<
         GaugeId,
         StateId,
@@ -987,17 +989,17 @@ where
     TxSubmit: Clone + Network<Tx, RejectReasons> + Send,
     Verifier: RemoteVerifier<PartiallySignedTx<SignedTxBuilder, TxInputs>, Tx> + Send,
     HarvestingFlow<StateId, Bearer, Ctx, PositionIndex, OnChainIndex>: BatchExecutor<
-        TaskId,
-        Harvesting<StateId>,
-        HarvestFlowEntityUpdates<StateId, Bearer, SignedTxBuilder, TxInputs>,
-        Error,
-    >,
+            TaskId,
+            Harvesting<StateId>,
+            HarvestFlowEntityUpdates<StateId, Bearer, SignedTxBuilder, TxInputs>,
+            Error,
+        >,
     BufferingFlow<GaugeId, StateId, Bearer, Ctx, OnChainIndex, FundingIndex>: BatchExecutor<
-        TaskId,
-        GaugeBuffering<GaugeId>,
-        BufferingFlowEntityUpdates<StateId, GaugeId, Bearer, SignedTxBuilder, TxInputs>,
-        Error,
-    >,
+            TaskId,
+            GaugeBuffering<GaugeId>,
+            BufferingFlowEntityUpdates<StateId, GaugeId, Bearer, SignedTxBuilder, TxInputs>,
+            Error,
+        >,
     Ctx: Send
         + Clone
         + Has<DeployedValidator<{ ProtocolValidator::BufferWallet as u8 }>>

--- a/splash-reward-distributor/src/engine/executor.rs
+++ b/splash-reward-distributor/src/engine/executor.rs
@@ -30,10 +30,10 @@ use log::{error, warn};
 use pallas_network::miniprotocols::localtxsubmission::cardano_node_errors::{
     ApplyTxError, ConwayLedgerPredFailure, ConwayUtxoPredFailure, ConwayUtxowPredFailure, TxInput,
 };
-use rs_merkle::MerkleTree;
 use rs_merkle::algorithms::Keccak256;
-use serde::Serialize;
+use rs_merkle::MerkleTree;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use spectrum_cardano_lib::collateral::Collateral;
 use spectrum_cardano_lib::hash::hash_transaction_canonical;
 use spectrum_cardano_lib::output::FinalizedTxOut;
@@ -43,13 +43,12 @@ use spectrum_cardano_lib::transaction::TransactionOutputExtension;
 use spectrum_cardano_lib::types::TryFromPData;
 use spectrum_cardano_lib::value::ValueExtension;
 use spectrum_cardano_lib::{AssetClass, AssetName, NetworkId, OutputRef, Token};
-use spectrum_offchain::domain::Has;
 use spectrum_offchain::domain::event::Predicted;
+use spectrum_offchain::domain::Has;
 use spectrum_offchain::network::Network;
 use spectrum_offchain::tx_hash::CanonicalHash;
 use spectrum_offchain_cardano::deployment::DeployedValidator;
 use spectrum_offchain_cardano::tx_submission::RejectReasons;
-use splash_dao_offchain::GenesisEpochStartTime;
 use splash_dao_offchain::constants::SPLASH_NAME;
 use splash_dao_offchain::deployment::{DaoScriptData, ProtocolValidator};
 use splash_dao_offchain::entities::onchain::funding_box::{FundingBox, FundingBoxId};
@@ -58,15 +57,16 @@ use splash_dao_offchain::funding::{AvailableFundingBoxes, FundingRepo};
 use splash_dao_offchain::protocol_config::{OperatorCreds, SplashPolicy};
 use splash_dao_offchain::routines::actions::{BlueprintEstimates, DaoTxBlueprint};
 use splash_dao_offchain::routines::{
-    FundingBoxChanges, Slot, last_slot_of_epoch, slot_to_epoch, time_millis_to_epoch,
+    last_slot_of_epoch, slot_to_epoch, time_millis_to_epoch, FundingBoxChanges, Slot,
 };
-use splash_dao_offchain::{CurrentEpoch, GenesisEpochStartTime};
+use splash_dao_offchain::GenesisEpochStartTime;
 use splash_yf_offchain::entities::buffer_wallet::{
     BufferWallet, BufferWalletAction, BufferWalletConfig, BufferWalletWrap,
 };
 use splash_yf_offchain::entities::gauge::Gauge;
 use splash_yf_offchain::entities::harvest_order::{HarvestOrder, HarvestOrderAction};
 use splash_yf_offchain::events::EntityUpdated;
+use splash_yf_offchain::Epoch;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -371,12 +371,10 @@ where
             let splash_policy = self.ctx.select::<SplashPolicy>().0;
             let splash_asset_class = AssetClass::Token(Token(splash_policy, splash_asset_name));
 
-            assert!(
-                bw_out
-                    .value_mut()
-                    .checked_sub(&make_splash_value(splash_asset_class, batch.total_payout))
-                    .is_ok()
-            );
+            assert!(bw_out
+                .value_mut()
+                .checked_sub(&make_splash_value(splash_asset_class, batch.total_payout))
+                .is_ok());
 
             let buffer_wallet_output = TransactionOutputBuilder::new()
                 .with_address(bw_out.address().clone())
@@ -881,7 +879,7 @@ where
     let network_id = ctx.select::<NetworkId>();
     let now_slot = posix_to_slot(now, network_id);
     let genesis_start_time = ctx.select::<GenesisEpochStartTime>();
-    let current_epoch = CurrentEpoch(slot_to_epoch(now_slot, genesis_start_time, network_id).0);
+    let current_epoch = slot_to_epoch(now_slot, genesis_start_time, network_id);
     let last_slot_of_epoch = last_slot_of_epoch(current_epoch, genesis_start_time, network_id);
     let reward_tx_ttl = ctx.select::<RewardTxTtl>();
     let ttl = last_slot_of_epoch.min(now_slot + reward_tx_ttl.0);
@@ -927,19 +925,19 @@ pub struct Executor<
 }
 
 impl<
-    GaugeId,
-    StateId,
-    Bearer,
-    Tx,
-    TxInputs,
-    Ctx,
-    TxErr,
-    PositionIndex,
-    OnChainIndex,
-    FundingIndex,
-    TxSubmit,
-    Verifier,
->
+        GaugeId,
+        StateId,
+        Bearer,
+        Tx,
+        TxInputs,
+        Ctx,
+        TxErr,
+        PositionIndex,
+        OnChainIndex,
+        FundingIndex,
+        TxSubmit,
+        Verifier,
+    >
     Executor<
         GaugeId,
         StateId,
@@ -978,18 +976,18 @@ impl<
 
 #[async_trait]
 impl<
-    GaugeId,
-    StateId,
-    Bearer,
-    Tx,
-    TxInputs,
-    Ctx,
-    PositionIndex,
-    OnChainIndex,
-    FundingIndex,
-    TxSubmit,
-    Verifier,
-> BatchExecutor<TaskId, Task<GaugeId, StateId>, TransactionHash, Error>
+        GaugeId,
+        StateId,
+        Bearer,
+        Tx,
+        TxInputs,
+        Ctx,
+        PositionIndex,
+        OnChainIndex,
+        FundingIndex,
+        TxSubmit,
+        Verifier,
+    > BatchExecutor<TaskId, Task<GaugeId, StateId>, TransactionHash, Error>
     for Executor<
         GaugeId,
         StateId,
@@ -1022,17 +1020,17 @@ where
     TxSubmit: Clone + Network<Tx, RejectReasons> + Send,
     Verifier: RemoteVerifier<PartiallySignedTx<SignedTxBuilder, TxInputs>, Tx> + Send,
     HarvestingFlow<StateId, Bearer, Ctx, PositionIndex, OnChainIndex>: BatchExecutor<
-            TaskId,
-            Harvesting<StateId>,
-            HarvestFlowEntityUpdates<StateId, Bearer, SignedTxBuilder, TxInputs>,
-            Error,
-        >,
+        TaskId,
+        Harvesting<StateId>,
+        HarvestFlowEntityUpdates<StateId, Bearer, SignedTxBuilder, TxInputs>,
+        Error,
+    >,
     BufferingFlow<GaugeId, StateId, Bearer, Ctx, OnChainIndex, FundingIndex>: BatchExecutor<
-            TaskId,
-            GaugeBuffering<GaugeId>,
-            BufferingFlowEntityUpdates<StateId, GaugeId, Bearer, SignedTxBuilder, TxInputs>,
-            Error,
-        >,
+        TaskId,
+        GaugeBuffering<GaugeId>,
+        BufferingFlowEntityUpdates<StateId, GaugeId, Bearer, SignedTxBuilder, TxInputs>,
+        Error,
+    >,
     Ctx: Send
         + Clone
         + Has<DeployedValidator<{ ProtocolValidator::BufferWallet as u8 }>>

--- a/splash-reward-distributor/src/engine/executor.rs
+++ b/splash-reward-distributor/src/engine/executor.rs
@@ -3,6 +3,7 @@ use crate::constants::{
     GAUGE_BUFFERING_TX_FEE_DELTA, GAUGE_BUFFERING_TX_MINIMAL_FUNDING_BOX_BALANCE,
     HARVESTING_TX_ASSUMED_BASE_FEE, HARVESTING_TX_FEE_DELTA,
 };
+use crate::context::RewardTxTtl;
 use crate::engine::batch::{BufferingBatch, HarvestBatch, OrderWithSpendDetails};
 use crate::engine::resolved_tx::{
     CardanoTxInput, CardanoTxInputs, PartiallySignedCardanoTx, PartiallySignedTx,
@@ -15,7 +16,9 @@ use async_trait::async_trait;
 use bloom_offchain::execution_engine::bundled::Bundled;
 use cml_chain::builders::input_builder::{InputBuilderResult, SingleInputBuilder};
 use cml_chain::builders::output_builder::{SingleOutputBuilderResult, TransactionOutputBuilder};
-use cml_chain::builders::tx_builder::{ChangeSelectionAlgo, SignedTxBuilder, TransactionUnspentOutput};
+use cml_chain::builders::tx_builder::{
+    ChangeSelectionAlgo, SignedTxBuilder, TransactionBuilder, TransactionUnspentOutput,
+};
 use cml_chain::builders::witness_builder::{
     NativeScriptWitnessInfo, PartialPlutusWitness, PlutusScriptWitness,
 };
@@ -35,6 +38,7 @@ use spectrum_cardano_lib::collateral::Collateral;
 use spectrum_cardano_lib::hash::hash_transaction_canonical;
 use spectrum_cardano_lib::output::FinalizedTxOut;
 use spectrum_cardano_lib::plutus_data::{DatumExtension, IntoPlutusData};
+use spectrum_cardano_lib::time::posix_to_slot;
 use spectrum_cardano_lib::transaction::TransactionOutputExtension;
 use spectrum_cardano_lib::types::TryFromPData;
 use spectrum_cardano_lib::value::ValueExtension;
@@ -53,8 +57,10 @@ use splash_dao_offchain::entities::onchain::smart_farm::{self, FarmId};
 use splash_dao_offchain::funding::{AvailableFundingBoxes, FundingRepo};
 use splash_dao_offchain::protocol_config::{OperatorCreds, SplashPolicy};
 use splash_dao_offchain::routines::actions::{BlueprintEstimates, DaoTxBlueprint};
-use splash_dao_offchain::routines::{FundingBoxChanges, Slot, slot_to_epoch, time_millis_to_epoch};
-use splash_yf_offchain::Epoch;
+use splash_dao_offchain::routines::{
+    FundingBoxChanges, Slot, last_slot_of_epoch, slot_to_epoch, time_millis_to_epoch,
+};
+use splash_dao_offchain::{CurrentEpoch, GenesisEpochStartTime};
 use splash_yf_offchain::entities::buffer_wallet::{
     BufferWallet, BufferWalletAction, BufferWalletConfig, BufferWalletWrap,
 };
@@ -64,7 +70,7 @@ use splash_yf_offchain::events::EntityUpdated;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::marker::PhantomData;
-use std::time::SystemTime;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Control<TaskId> {
@@ -137,7 +143,8 @@ where
         + Has<OperatorCreds>
         + Has<Collateral>
         + Has<GenesisEpochStartTime>
-        + Has<NetworkId>,
+        + Has<NetworkId>
+        + Has<RewardTxTtl>,
 {
     async fn feed(&mut self, task_id: TaskId, task: Harvesting<OutputRef>) -> Control<TaskId> {
         let (harvest_order, tx_out) = if let Some(order) = self
@@ -432,6 +439,9 @@ where
             tx_builder
                 .add_collateral(InputBuilderResult::from(self.ctx.select::<Collateral>()))
                 .unwrap();
+
+            set_tx_ttl(&mut tx_builder, &self.ctx);
+
             let inputs = tx_builder
                 .get_inputs()
                 .clone()
@@ -514,7 +524,10 @@ where
         + Has<DeployedValidator<{ ProtocolValidator::BufferWallet as u8 }>>
         + Has<DeployedValidator<{ ProtocolValidator::SmartFarm as u8 }>>
         + Has<DeployedValidator<{ ProtocolValidator::PermManager as u8 }>>
-        + Has<SplashPolicy>,
+        + Has<SplashPolicy>
+        + Has<RewardTxTtl>
+        + Has<GenesisEpochStartTime>
+        + Has<NetworkId>,
     OnChainIndex: GaugeIndex<FarmId, OutputRef, FinalizedTxOut>
         + AuthManagerIndex<FarmId, OutputRef, FinalizedTxOut>
         + BufferWalletIndex<OutputRef, FinalizedTxOut>
@@ -767,6 +780,9 @@ where
             tx_builder
                 .add_collateral(InputBuilderResult::from(self.ctx.select::<Collateral>()))
                 .unwrap();
+
+            set_tx_ttl(&mut tx_builder, &self.ctx);
+
             let inputs = tx_builder
                 .get_inputs()
                 .clone()
@@ -854,6 +870,23 @@ where
             panic!("No gauge buffering batch exists (didn't call .feed())")
         }
     }
+}
+
+/// Set TX TTL to be within the current epoch and under the configured reward TX TTL.
+fn set_tx_ttl<Ctx>(tx_builder: &mut TransactionBuilder, ctx: &Ctx)
+where
+    Ctx: Has<RewardTxTtl> + Has<GenesisEpochStartTime> + Has<NetworkId>,
+{
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let network_id = ctx.select::<NetworkId>();
+    let now_slot = posix_to_slot(now, network_id);
+    let genesis_start_time = ctx.select::<GenesisEpochStartTime>();
+    let current_epoch = CurrentEpoch(slot_to_epoch(now_slot, genesis_start_time, network_id).0);
+    let last_slot_of_epoch = last_slot_of_epoch(current_epoch, genesis_start_time, network_id);
+    let reward_tx_ttl = ctx.select::<RewardTxTtl>();
+    let ttl = last_slot_of_epoch.min(now_slot + reward_tx_ttl.0);
+    tx_builder.set_validity_start_interval(now_slot);
+    tx_builder.set_ttl(ttl);
 }
 
 fn make_splash_value(splash_asset_class: AssetClass, amount: u64) -> Value {

--- a/splash-reward-distributor/src/engine/mod.rs
+++ b/splash-reward-distributor/src/engine/mod.rs
@@ -9,6 +9,7 @@ pub mod verifier_engine;
 use crate::engine::executor::{BatchExecutor, Control, Error as ExecutorError};
 use crate::engine::queue::{QueueCmd, StrikeTime, TaskQueue};
 use crate::engine::task::{Task, TaskId};
+use async_primitives::beacon::{Beacon, Once};
 use cardano_chain_sync::atomic_flow::{BlockEvents, TransactionHandle};
 use cml_crypto::TransactionHash;
 use futures::channel::mpsc::Receiver;
@@ -22,6 +23,7 @@ use std::future::Future;
 use std::ops::ControlFlow;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use tokio::time::Sleep;
 
 #[derive(Debug, Clone, Copy, Deserialize)]
 pub struct EngineConfig {
@@ -34,6 +36,10 @@ pub struct Engine<U, Q, E> {
     executor: E,
     current_task: Option<Pin<Box<dyn Future<Output = ControlFlow<(), ()>> + Send>>>,
     dropped_unconfirmed_tx_hashes_recv: Receiver<TransactionHash>,
+    /// Agent is synced with the network.
+    state_synced: Beacon,
+    blocker: Option<Once>,
+    initial_tx_ttl_delay: Option<Pin<Box<Sleep>>>,
     conf: EngineConfig,
 }
 
@@ -44,6 +50,8 @@ impl<U, Q, E> Engine<U, Q, E> {
         executor: E,
         conf: EngineConfig,
         dropped_unconfirmed_tx_hashes_recv: Receiver<TransactionHash>,
+        state_synced: Beacon,
+        initial_tx_ttl_delay: Sleep,
     ) -> Self {
         Self {
             event_stream,
@@ -52,6 +60,9 @@ impl<U, Q, E> Engine<U, Q, E> {
             current_task: None,
             conf,
             dropped_unconfirmed_tx_hashes_recv,
+            state_synced,
+            blocker: None,
+            initial_tx_ttl_delay: Some(Box::pin(initial_tx_ttl_delay)),
         }
     }
 
@@ -87,8 +98,6 @@ where
                     if cf.is_break() {
                         break;
                     }
-                } else {
-                    break;
                 }
             }
 
@@ -103,6 +112,27 @@ where
                 Stream::poll_next(Pin::new(&mut self.dropped_unconfirmed_tx_hashes_recv), cx)
             {
                 self.block_on(reschedule_tasks_from_dropped_tx(tx_hash, queue));
+                continue;
+            }
+
+            // Wait until initial tx TTL delay is resolved (CompleteDataLoss stressor).
+            if let Some(mut initial_tx_ttl_delay) = self.initial_tx_ttl_delay.take() {
+                if Future::poll(Pin::new(&mut initial_tx_ttl_delay), cx).is_pending() {
+                    self.initial_tx_ttl_delay = Some(initial_tx_ttl_delay);
+                    continue;
+                }
+            }
+
+            // Wait until blockers are resolved.
+            if let Some(mut blocker) = self.blocker.take() {
+                if Future::poll(Pin::new(&mut blocker), cx).is_pending() {
+                    self.blocker = Some(blocker);
+                    continue;
+                }
+            }
+
+            if !self.state_synced.read() {
+                self.blocker = Some(self.state_synced.once(true));
                 continue;
             }
             let executor = self.executor.clone();

--- a/splash-reward-distributor/src/engine/verifier.rs
+++ b/splash-reward-distributor/src/engine/verifier.rs
@@ -19,18 +19,18 @@ use spectrum_offchain::ledger::TryFromLedger;
 use spectrum_offchain::tx_hash::CanonicalHash;
 use spectrum_offchain::tx_prover::TxProver;
 use spectrum_offchain_cardano::deployment::DeployedScriptInfo;
+use splash_dao_offchain::GenesisEpochStartTime;
 use splash_dao_offchain::deployment::ProtocolValidator;
 use splash_dao_offchain::entities::onchain::smart_farm::FarmId;
 use splash_dao_offchain::protocol_config::{
     BufferWalletAuthPolicy, OperatorCreds, PermManagerAuthPolicy, SplashPolicy,
 };
 use splash_dao_offchain::routines::slot_to_epoch;
-use splash_dao_offchain::GenesisEpochStartTime;
+use splash_yf_offchain::Epoch;
 use splash_yf_offchain::entities::gauge::GaugeWithdrawals;
 use splash_yf_offchain::entities::{SplashTokenDecrease, SplashTokenIncrease};
 use splash_yf_offchain::events::{OnChainEvent, SplashPayout};
 use splash_yf_offchain::settings::MinLovelacePerHarvest;
-use splash_yf_offchain::Epoch;
 use std::collections::HashSet;
 use std::marker::PhantomData;
 
@@ -162,9 +162,11 @@ where
     }
 
     fn confirm_gauge_buffering_tx(&mut self, tx_hash: TransactionHash) {
-        assert!(!self
-            .unconfirmed_harvest_tx_index
-            .confirm_tx(tx_hash, &HashSet::new()));
+        assert!(
+            !self
+                .unconfirmed_harvest_tx_index
+                .confirm_tx(tx_hash, &HashSet::new())
+        );
     }
 
     fn rollback_harvest_tx(
@@ -309,9 +311,9 @@ where
                         {
                             if amount != *payout {
                                 info!(
-                                "Accumulated reward amount {} (determined from lp-indexer) != harvest withdrawal amount {}",
-                                amount, *payout
-                            );
+                                    "Accumulated reward amount {} (determined from lp-indexer) != harvest withdrawal amount {}",
+                                    amount, *payout
+                                );
                                 return None;
                             }
                             if current_epoch > latest_epoch_inclusive.next() {

--- a/splash-reward-distributor/src/engine/verifier.rs
+++ b/splash-reward-distributor/src/engine/verifier.rs
@@ -1,6 +1,6 @@
 use crate::accounts::{AccountReward, Accounts};
 use crate::engine::resolved_tx::PartiallySignedCardanoTx;
-use crate::entity_index::{AuthManagerIndex, HarvestOrderIndex, UnconfirmedHarvestTxIndex};
+use crate::entity_index::{AuthManagerIndex, HarvestOrderIndex, UnconfirmedRewardTxIndex};
 use cml_chain::builders::tx_builder::SignedTxBuilder;
 use cml_chain::certs::Credential;
 use cml_chain::crypto::Vkeywitness;
@@ -153,7 +153,7 @@ impl<Index, PositionIndex, UHarvestIndex, Prov> VerifierHandleLedgerEvent
 where
     Index: Send + Sync,
     PositionIndex: Accounts<OutputRef> + Send + Sync,
-    UHarvestIndex: UnconfirmedHarvestTxIndex + Send + Sync,
+    UHarvestIndex: UnconfirmedRewardTxIndex + Send + Sync,
     Prov: TxProver<SignedTxBuilder, Transaction> + Send + Sync,
 {
     fn confirm_harvest_tx(&mut self, tx_hash: TransactionHash, confirmed_user_harvests: &[Ed25519KeyHash]) {
@@ -227,7 +227,7 @@ where
         + Send
         + Sync,
     PositionIndex: Accounts<OutputRef> + Send + Sync,
-    UHarvestIndex: UnconfirmedHarvestTxIndex + Send + Sync,
+    UHarvestIndex: UnconfirmedRewardTxIndex + Send + Sync,
     Prov: TxProver<SignedTxBuilder, Transaction> + Send + Sync,
     Ctx: Has<MinLovelacePerHarvest>
         + Has<DeployedScriptInfo<{ ProtocolValidator::HarvestOrder as u8 }>>
@@ -372,6 +372,7 @@ where
                 let tx_view = to_tx_view_partially_resolved(tx, current_slot);
                 if let Some(OnChainEvent::BotGaugeBufferingAction {
                     drained_gauges: GaugeWithdrawals(drained_gauges),
+                    buffer_wallet_update,
                     buffer_wallet_deposited_amount: SplashTokenIncrease(bw_deposited_amount),
                     ..
                 }) = OnChainEvent::try_from_ledger(&tx_view, ctx)
@@ -387,7 +388,14 @@ where
 
                     // Check that all rewards are only deposited in the buffer wallet
                     assert_eq!(total_rewards, bw_deposited_amount);
-                    return Some(self.prover.prove(tx.tx.clone()));
+                    let consumed_buffer_wallet_tx_hash = buffer_wallet_update.consumed?.tx_hash();
+                    if self.unconfirmed_harvest_tx_index.try_add_tx(
+                        consumed_buffer_wallet_tx_hash,
+                        tx_hash,
+                        HashSet::new(),
+                    ) {
+                        return Some(self.prover.prove(tx.tx.clone()));
+                    }
                 }
             }
         }

--- a/splash-reward-distributor/src/engine/verifier_engine.rs
+++ b/splash-reward-distributor/src/engine/verifier_engine.rs
@@ -80,7 +80,10 @@ where
             Cosign(TxCosignRequest, oneshot::Sender<Option<Transaction>>),
         }
         loop {
-            // Use poll_fn to manually poll both streams with bias toward ledger events
+            // Use poll_fn to manually poll both streams with bias toward ledger events (note that
+            // tokio::select! isn't appropriate here because the macro `.awaits` on multiple futures
+            // at the top level. This doesn't work for us because we need to inspect Option<..>
+            // values.
             let result = poll_fn(|cx| {
                 // First try ledger events (biased)
                 if let Poll::Ready(Some((event, tx))) = self.ledger_event_stream.poll_next_unpin(cx) {

--- a/splash-reward-distributor/src/engine/verifier_engine.rs
+++ b/splash-reward-distributor/src/engine/verifier_engine.rs
@@ -1,34 +1,49 @@
-use std::marker::PhantomData;
+use std::future::Future;
+use std::pin::Pin;
+use std::{future::poll_fn, marker::PhantomData, task::Poll};
 
+use async_primitives::beacon::{Beacon, Once};
 use cardano_chain_sync::atomic_flow::{BlockEvents, TransactionHandle};
 use cml_chain::transaction::Transaction;
 use futures::Stream;
+use futures::StreamExt;
 use spectrum_cardano_lib::NetworkId;
 use spectrum_offchain::domain::Has;
 use spectrum_offchain_cardano::deployment::DeployedScriptInfo;
 use splash_dao_offchain::{deployment::ProtocolValidator, protocol_config::SplashPolicy};
 use splash_yf_offchain::{events::OnChainEvent, settings::MinLovelacePerHarvest};
 use tokio::sync::oneshot;
-use tokio_stream::StreamExt;
+use tokio::time::Sleep;
 
-use crate::engine::{
-    resolved_tx::PartiallySignedCardanoTx,
-    verifier::{AuthorizedExecutors, LocalVerifier, TxCosignRequest, VerifierHandleLedgerEvent},
+use crate::engine::verifier::{
+    AuthorizedExecutors, LocalVerifier, TxCosignRequest, VerifierHandleLedgerEvent,
 };
 
 pub struct VerifierEngine<U, R, Verifier, Ctx> {
     ledger_event_stream: U,
     cosign_request_stream: R,
     local_verifier: Verifier,
+    state_synced: Beacon,
+    blocker: Option<Once>,
+    initial_tx_ttl_delay: Option<Pin<Box<Sleep>>>,
     pd: PhantomData<Ctx>,
 }
 
 impl<U, R, Verifier, Ctx> VerifierEngine<U, R, Verifier, Ctx> {
-    pub fn new(ledger_event_stream: U, cosign_request_stream: R, local_verifier: Verifier) -> Self {
+    pub fn new(
+        ledger_event_stream: U,
+        cosign_request_stream: R,
+        local_verifier: Verifier,
+        state_synced: Beacon,
+        initial_tx_ttl_delay: Sleep,
+    ) -> Self {
         Self {
             ledger_event_stream,
             cosign_request_stream,
             local_verifier,
+            state_synced,
+            blocker: None,
+            initial_tx_ttl_delay: Some(Box::pin(initial_tx_ttl_delay)),
             pd: PhantomData,
         }
     }
@@ -57,14 +72,61 @@ where
         + Sync,
 {
     pub async fn run(mut self, ctx: Ctx) {
+        enum T<GaugeId, StateId, Bearer> {
+            Ledger(
+                BlockEvents<OnChainEvent<GaugeId, StateId, Bearer>>,
+                TransactionHandle,
+            ),
+            Cosign(TxCosignRequest, oneshot::Sender<Option<Transaction>>),
+        }
         loop {
-            tokio::select! {
-                Some(event) = self.ledger_event_stream.next() => {
-                    process_ledger_event(event, &mut self.local_verifier).await;
+            // Use poll_fn to manually poll both streams with bias toward ledger events
+            let result = poll_fn(|cx| {
+                // First try ledger events (biased)
+                if let Poll::Ready(Some((event, tx))) = self.ledger_event_stream.poll_next_unpin(cx) {
+                    return Poll::Ready(Some(T::Ledger(event, tx)));
                 }
-                Some((tx, sender)) = self.cosign_request_stream.next() => {
-                    sender.send(self.local_verifier.try_approve(&tx, &ctx).await).unwrap();
+
+                // Wait until initial tx TTL delay is resolved (CompleteDataLoss stressor).
+                if let Some(mut initial_tx_ttl_delay) = self.initial_tx_ttl_delay.take() {
+                    if Future::poll(Pin::new(&mut initial_tx_ttl_delay), cx).is_pending() {
+                        self.initial_tx_ttl_delay = Some(initial_tx_ttl_delay);
+                        return Poll::Ready(None);
+                    }
                 }
+
+                // Wait until blockers are resolved.
+                if let Some(mut blocker) = self.blocker.take() {
+                    if Future::poll(Pin::new(&mut blocker), cx).is_pending() {
+                        self.blocker = Some(blocker);
+                        return Poll::Ready(None);
+                    }
+                }
+
+                if !self.state_synced.read() {
+                    self.blocker = Some(self.state_synced.once(true));
+                    return Poll::Ready(None);
+                }
+
+                // Then try cosign requests
+                if let Poll::Ready(Some((tx, sender))) = self.cosign_request_stream.poll_next_unpin(cx) {
+                    return Poll::Ready(Some(T::Cosign(tx, sender)));
+                }
+
+                Poll::Pending
+            })
+            .await;
+
+            match result {
+                Some(T::Ledger(event, tx)) => {
+                    process_ledger_event((event, tx), &mut self.local_verifier).await;
+                }
+                Some(T::Cosign(tx, sender)) => {
+                    sender
+                        .send(self.local_verifier.try_approve(&tx, &ctx).await)
+                        .unwrap();
+                }
+                None => (),
             }
         }
     }

--- a/splash-reward-distributor/src/entity_index/chained_tx_graph.rs
+++ b/splash-reward-distributor/src/entity_index/chained_tx_graph.rs
@@ -8,11 +8,11 @@ use petgraph::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::entity_index::UnconfirmedHarvestTxIndex;
+use crate::entity_index::UnconfirmedRewardTxIndex;
 
-/// This store mantains a directed graph where nodes represent validated harvest TXs that can be
-/// cosigned by the verifier. An edge from a node M to N indicates that the TX N has spent the
-/// `buffer_wallet` output of M. None of these TXs have been confirmed on-chain, and so a
+/// This store mantains a directed graph where nodes represent validated harvest or gauge buffering
+/// TXs that can be cosigned by the verifier. An edge from a node M to N indicates that the TX N has
+/// spent the `buffer_wallet` output of M. None of these TXs have been confirmed on-chain, and so a
 /// path of nodes from a source (no incoming edges) to a sink (no outgoing edges) represents a
 /// single TX-chain.
 ///
@@ -26,7 +26,7 @@ use crate::entity_index::UnconfirmedHarvestTxIndex;
 /// from a confirmed TX. The graph must be notified of changes to this through the use of
 /// `confirm_tx()` and `rollback()` methods.
 #[derive(Serialize, Deserialize)]
-pub struct ChainedHarvestTxGraph {
+pub struct ChainedRewardTxGraph {
     gr: StableDiGraph<NodeData, ()>,
     /// Contains all users who have already confirmed to have harvested in the current epoch.
     last_confirmed_user_harvests: HashSet<Ed25519KeyHash>,
@@ -34,7 +34,7 @@ pub struct ChainedHarvestTxGraph {
     last_confirmed_buffer_wallet_tx_hash: TransactionHash,
 }
 
-impl UnconfirmedHarvestTxIndex for ChainedHarvestTxGraph {
+impl UnconfirmedRewardTxIndex for ChainedRewardTxGraph {
     /// Attempt to add a new TX to the store. If the TX spends a valid `buffer_wallet` input and
     /// does not perform double-harvesting, it will be added and `true` is returned.
     ///
@@ -186,7 +186,7 @@ impl UnconfirmedHarvestTxIndex for ChainedHarvestTxGraph {
     }
 }
 
-impl ChainedHarvestTxGraph {
+impl ChainedRewardTxGraph {
     pub fn new() -> Self {
         Self {
             gr: StableDiGraph::new(),
@@ -253,13 +253,13 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use spectrum_offchain::tx_hash::CanonicalHash;
 
-    use crate::entity_index::{chained_tx_graph::ChainedHarvestTxGraph, UnconfirmedHarvestTxIndex};
+    use crate::entity_index::{chained_tx_graph::ChainedRewardTxGraph, UnconfirmedRewardTxIndex};
 
     #[test]
     fn test_full_tx_chain_confirmation() {
         let last_confirmed_user_harvests: HashSet<_> = (0_u8..10).map(gen_key_hash).collect();
         let tx_hashes: Vec<_> = (0_u8..20).map(gen_tx_hash).collect();
-        let mut gr = ChainedHarvestTxGraph::new();
+        let mut gr = ChainedRewardTxGraph::new();
         gr.confirm_tx(tx_hashes[0], &last_confirmed_user_harvests);
         assert_eq!(gr.last_confirmed_user_harvests.len(), 10);
         let key_hash = gen_key_hash(10);
@@ -324,7 +324,7 @@ mod tests {
         // 3. Confirm T_4, which leads to removal of T_5 (and so no more nodes in the unconfirmed graph)
         let last_confirmed_user_harvests: HashSet<_> = (0_u8..10).map(gen_key_hash).collect();
         let tx_hashes: Vec<_> = (0_u8..20).map(gen_tx_hash).collect();
-        let mut gr = ChainedHarvestTxGraph::new();
+        let mut gr = ChainedRewardTxGraph::new();
         gr.confirm_tx(tx_hashes[0], &last_confirmed_user_harvests);
 
         assert!(gr.try_add_tx(

--- a/splash-reward-distributor/src/entity_index/mod.rs
+++ b/splash-reward-distributor/src/entity_index/mod.rs
@@ -93,8 +93,8 @@ pub trait AuthManagerIndex<GaugeId, StateId, Bearer> {
     async fn remove_auth_manager(&self, state_id: StateId) -> Option<StateId>;
 }
 
-pub trait UnconfirmedHarvestTxIndex {
-    /// Try adding a harvest TX to the index, returning true if successful.
+pub trait UnconfirmedRewardTxIndex {
+    /// Try adding a harvest or gauge buffering TX to the index, returning true if successful.
     ///
     /// `buffer_wallet_input_tx_hash` must refer to a TX hash of a confirmed buffering/harvest
     /// action or an unconfirmed harvest operation that has **already been** cosigned by this

--- a/splash-reward-distributor/src/main.rs
+++ b/splash-reward-distributor/src/main.rs
@@ -10,12 +10,12 @@ mod pipeline;
 use crate::accounts::PositionIndex;
 use crate::api_endpoint::{handle_request_cosignature, VerifierAppState};
 use crate::config::AppConfig;
-use crate::context::{RewardBotRuntimeContext, VerifierRuntimeContext};
+use crate::context::{RewardBotRuntimeContext, RewardTxTtl, VerifierRuntimeContext};
 use crate::engine::executor::Executor;
 use crate::engine::queue::RocksDB;
 use crate::engine::verifier::{AuthorizedExecutors, HttpVerifier, Verifier};
 use crate::engine::verifier_engine::VerifierEngine;
-use crate::entity_index::chained_tx_graph::ChainedHarvestTxGraph;
+use crate::entity_index::chained_tx_graph::ChainedRewardTxGraph;
 use crate::entity_index::rocksdb::IndexerDB;
 use crate::entity_index::update_index_from_mempool_dropped_tx;
 use crate::pipeline::event_pipeline;
@@ -46,6 +46,7 @@ use splash_dao_offchain::deployment::{
 use splash_dao_offchain::funding::FundingRepoRocksDB;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing_subscriber::fmt::Subscriber;
 
@@ -96,7 +97,7 @@ async fn run_reward_bot(args: AppArgs) {
 
     let state_synced = Beacon::relaxed(false);
     let (flow_driver, block_events) = atomic_block_flow(
-        Box::pin(chain_sync_stream(chain_sync, state_synced)),
+        Box::pin(chain_sync_stream(chain_sync, state_synced.clone())),
         chain_sync_cache,
     );
 
@@ -142,6 +143,7 @@ async fn run_reward_bot(args: AppArgs) {
         network_id: config.network_id,
         genesis_epoch_start_time: config.ve_config.epoch_start.into(),
         authorized_executors: AuthorizedExecutors(config.authorized_executors),
+        reward_tx_ttl: RewardTxTtl(config.reward_tx_ttl_in_slots),
     };
 
     let ctx = RewardBotRuntimeContext {
@@ -164,12 +166,15 @@ async fn run_reward_bot(args: AppArgs) {
 
     let queue = RocksDB::new(config.persistent_queue_db_path);
     let (engine_mailbox_snd, engine_mailbox) = mpsc::channel(1024);
+    let initial_tx_ttl_delay = tokio::time::sleep(Duration::from_secs(config.reward_tx_ttl_in_slots));
     let engine = engine::Engine::new(
         engine_mailbox,
         queue,
         executor,
         config.engine,
         failed_tx_hash_recv,
+        state_synced,
+        initial_tx_ttl_delay,
     );
 
     let processes = FuturesUnordered::new();
@@ -255,7 +260,7 @@ async fn run_verifier(args: AppArgs) {
 
     let state_synced = Beacon::relaxed(false);
     let (flow_driver, block_events) = atomic_block_flow(
-        Box::pin(chain_sync_stream(chain_sync, state_synced)),
+        Box::pin(chain_sync_stream(chain_sync, state_synced.clone())),
         chain_sync_cache,
     );
     let (confirmed_txs_snd, mut confirmed_txs_recv) =
@@ -283,6 +288,7 @@ async fn run_verifier(args: AppArgs) {
         network_id: config.network_id,
         genesis_epoch_start_time: config.ve_config.epoch_start.into(),
         authorized_executors: AuthorizedExecutors(config.authorized_executors),
+        reward_tx_ttl: RewardTxTtl(config.reward_tx_ttl_in_slots),
     };
 
     let (voting_order_snd, voting_event_rcv) = mpsc::channel(100);
@@ -319,12 +325,19 @@ async fn run_verifier(args: AppArgs) {
     let verifier = Verifier::new(
         onchain_index,
         position_index,
-        ChainedHarvestTxGraph::new(),
+        ChainedRewardTxGraph::new(),
         config.ve_config.epoch_start.into(),
         config.network_id,
         OperatorProver::new(config.operator_sk),
     );
-    let engine = VerifierEngine::new(engine_mailbox, voting_event_rcv, verifier);
+    let initial_tx_ttl_delay = tokio::time::sleep(Duration::from_secs(config.reward_tx_ttl_in_slots));
+    let engine: VerifierEngine<_, _, _, VerifierRuntimeContext> = VerifierEngine::new(
+        engine_mailbox,
+        voting_event_rcv,
+        verifier,
+        state_synced,
+        initial_tx_ttl_delay,
+    );
     let engine_handle = tokio::spawn(engine.run(ctx));
     processes.push(engine_handle);
 

--- a/splash-yf-offchain/Cargo.toml
+++ b/splash-yf-offchain/Cargo.toml
@@ -11,6 +11,7 @@ spectrum-cardano-lib = { version = "0.1.0", path = "../spectrum-cardano-lib" }
 spectrum-offchain-cardano = { version = "1.0.0", path = "../spectrum-offchain-cardano" }
 spectrum-offchain = { version = "0.1.0", path = "../spectrum-offchain", features = ["cml-chain"] }
 splash-dao-offchain = { version = "1.0.0", path = "../splash-dao-offchain" }
+log = "0.4.17"
 cml-core = { git = "https://github.com/oskin1/cardano-multiplatform-lib.git", rev = "92fa3944388c51880a77209feda35e16e0289247" }
 cml-crypto = { git = "https://github.com/oskin1/cardano-multiplatform-lib.git", rev = "92fa3944388c51880a77209feda35e16e0289247" }
 cml-chain = { git = "https://github.com/oskin1/cardano-multiplatform-lib.git", rev = "92fa3944388c51880a77209feda35e16e0289247" }

--- a/splash-yf-offchain/src/entities/harvest_order.rs
+++ b/splash-yf-offchain/src/entities/harvest_order.rs
@@ -5,6 +5,7 @@ use cml_chain::{
     transaction::TransactionOutput,
 };
 use cml_crypto::{Ed25519KeyHash, RawBytesEncoding};
+use log::info;
 use serde::{Deserialize, Serialize};
 use spectrum_cardano_lib::{
     address::PlutusAddress,
@@ -140,20 +141,31 @@ where
 {
     let harvest_limit = ctx.select::<MinLovelacePerHarvest>();
     let lovelace_amount = output.value().coin;
-    if test_address(output.address(), ctx) && lovelace_amount >= harvest_limit.0 {
-        let datum = output.datum()?;
-        let HarvestOrderDatum {
-            account_key,
-            reward_receiver,
-            ..
-        } = datum.into_pd().map(HarvestOrderDatum::try_from_pd)??;
-        let harvest_order = HarvestOrder {
-            id: output_ref,
-            account_key,
-            issued_at,
-            reward_receiver,
-        };
-        return Some(harvest_order);
+    if test_address(output.address(), ctx) {
+        if lovelace_amount < harvest_limit.0 {
+            info!("Harvest order {} below limit: {:?}", output_ref, lovelace_amount);
+            return None;
+        }
+        if let Some(datum) = output.datum() {
+            if let Some(Some(HarvestOrderDatum {
+                account_key,
+                reward_receiver,
+                ..
+            })) = datum.into_pd().map(HarvestOrderDatum::try_from_pd)
+            {
+                let harvest_order = HarvestOrder {
+                    id: output_ref,
+                    account_key,
+                    issued_at,
+                    reward_receiver,
+                };
+                return Some(harvest_order);
+            } else {
+                info!("Harvest order {} has invalid datum", output_ref);
+            }
+        } else {
+            info!("Harvest order {} has no datum", output_ref);
+        }
     }
     None
 }

--- a/splash-yf-offchain/src/lib.rs
+++ b/splash-yf-offchain/src/lib.rs
@@ -35,16 +35,16 @@ impl Epoch {
     pub fn unwrap(self) -> u64 {
         self.0
     }
-    pub fn fist_slot(&self, slots_in_epoch: u64, epoch_start: Slot) -> Slot {
+    pub fn first_slot(&self, slots_in_epoch: u64, epoch_start: Slot) -> Slot {
         epoch_start + (self.0 * slots_in_epoch)
     }
     pub fn last_slot(&self, slots_in_epoch: u64, epoch_start: Slot) -> Slot {
-        self.fist_slot(slots_in_epoch, epoch_start) + slots_in_epoch - 1
+        self.first_slot(slots_in_epoch, epoch_start) + slots_in_epoch - 1
     }
     pub fn adjacent_epochs(&self, slots_in_epoch: u64, epoch_start: Slot) -> Vec<Self> {
         let last_slot = self.last_slot(slots_in_epoch, epoch_start);
         let mut result = Vec::new();
-        for slot in self.fist_slot(slots_in_epoch, epoch_start)..=last_slot {
+        for slot in self.first_slot(slots_in_epoch, epoch_start)..=last_slot {
             result.push(Self::unsafe_from_slot(slot, slots_in_epoch, epoch_start));
         }
         result


### PR DESCRIPTION
Stressors addressed:
- MalformedOrder (added `info!` log calls to describe why harvest order parse failed)
- CompleteDataLoss (ensure executor idle until TX TTL expired)
- LedgerStateNotYetSynced (prevent execution until chain-sync complete)
- HarvestOrderIncorrectSlot (set proper TX TTL)